### PR TITLE
Test/add tests and fixtures

### DIFF
--- a/modal_backend/utils/services.py
+++ b/modal_backend/utils/services.py
@@ -51,7 +51,7 @@ class NoteTypeService:
     async def create_note_type(cls, db: Session, note_type: NoteTypePost) -> NoteType:
         data = note_type.model_dump()
         type_id = data.get("type_id")
-        note_types = NoteType.query(session=db.session).filter(NoteType.type_id == type_id).first()
+        note_types = NoteType.query(session=db.session, with_deleted=True).filter(NoteType.type_id == type_id).first()
         if note_types:
             raise AlreadyExists(NoteType, type_id)
         new_note_type = NoteType.create(session=db.session, **data)

--- a/modal_backend/utils/services.py
+++ b/modal_backend/utils/services.py
@@ -51,7 +51,7 @@ class NoteTypeService:
     async def create_note_type(cls, db: Session, note_type: NoteTypePost) -> NoteType:
         data = note_type.model_dump()
         type_id = data.get("type_id")
-        note_types = NoteType.query(session=db.session, with_deleted=True).filter(NoteType.type_id == type_id).first()
+        note_types = NoteType.query(session=db.session).filter(NoteType.type_id == type_id).first()
         if note_types:
             raise AlreadyExists(NoteType, type_id)
         new_note_type = NoteType.create(session=db.session, **data)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ isort
 pytest
 pytest-cov
 pytest-mock
+testcontainers[postgres]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def client(get_app_with_test_settings, user_mock):
 
 
 def create_note_type(name: str, type_id: int, is_deleted: bool = False):
-    """Вспомогательная функция-мини-фабрика для создания разных типов модалок"""
+    """Вспомогательная функция-мини-фабрика для создания разных типов модалок в фикстуре note_types."""
     return NoteType(name=name, type_id=type_id, is_deleted=is_deleted)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,27 @@
 # Тут импорты
-import pytest
-from pytest import MonkeyPatch
-from pathlib import Path
 from functools import lru_cache
-from fastapi.testclient import TestClient
+from pathlib import Path
+
+import pytest
 from alembic import command
 from alembic.config import Config as AlembicConfig
-from testcontainers.postgres import PostgresContainer
-from modal_backend.settings import Settings
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+from testcontainers.postgres import PostgresContainer
+
+from modal_backend.settings import Settings
+
 
 class PostgresConfig:
     """Дата-класс со значениями для контейнера с тестовой БД и для alembic-миграции."""
+
     container_name: str = "modal-service-api_test"
     username: str = "postgres"
     host: str = "localhost"
     external_port: int = 5432
-    image: str = "postgres:15"    
+    image: str = "postgres:15"
     host_auth_method: str = "trust"
     alembic_ini: str = Path(__file__).resolve().parent.parent / "alembic.ini"
 
@@ -25,6 +29,7 @@ class PostgresConfig:
     def get_url(cls) -> str:
         """Возвращает URI для подключения к БД."""
         return f"postgresql://{cls.username}@{cls.host}:{cls.external_port}/postgres"
+
 
 @pytest.fixture(scope="session")
 def session_mp():
@@ -42,7 +47,7 @@ def get_settings_mock(session_mp):
         test_settings = Settings()
         test_settings.DB_DSN = PostgresConfig.get_url()
         return test_settings
-    
+
     dsn_mock = session_mp.setattr(name="modal_backend.settings.get_settings", value=get_test_settings)
     return dsn_mock
 
@@ -51,6 +56,7 @@ def get_settings_mock(session_mp):
 def get_app_with_test_settings(get_settings_mock):
     """Загрузка app с тестовыми настройками."""
     from modal_backend.routes import app
+
     return app
 
 
@@ -86,25 +92,23 @@ def engine(db_container):
 @pytest.fixture()
 def dbsession(engine):
     """Фикстура настройки Session для работы с БД в тестах, реализующая паттерн 'Транзакционный откат'"""
-    #берем соединение из пула
+    # берем соединение из пула
     connection = engine.connect()
-    #начинаем внешнюю транзакцию(на уровне соедниения)
+    # начинаем внешнюю транзакцию(на уровне соедниения)
     transaction = connection.begin()
-    #создаём сессю на основе взятого из пула соединения
+    # создаём сессю на основе взятого из пула соединения
     session = Session(bind=connection)
     yield session
-    #закрываем сессию
+    # закрываем сессию
     session.close()
-    #откатываем внешнюю транзакцию, все savepoint-ы откатываются, БД чиста
+    # откатываем внешнюю транзакцию, все savepoint-ы откатываются, БД чиста
     transaction.rollback()
-    #возвращаем соединение в пул
+    # возвращаем соединение в пул
     connection.close()
-    
+
+
 @pytest.fixture
 def client(mocker, get_app_with_test_settings):
     app = get_app_with_test_settings
     client = TestClient(app)
-    return client   
-
-    
-
+    return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,14 +136,14 @@ def client(get_app_with_test_settings, user_mock):
     return client
 
 
-def create_note_type(name: str, type_id: int, is_deleted: bool = False):
+def create_note_type(name: str, type_id: int):
     """Вспомогательная функция-мини-фабрика для создания разных типов модалок в фикстуре note_types."""
-    return NoteType(name=name, type_id=type_id, is_deleted=is_deleted)
+    return NoteType(name=name, type_id=type_id)
 
 
 @pytest.fixture()
 def note_types(dbsession):
-    """Создает три разных типа модалок, один тип помечен на удаление."""
+    """Создает три разных типа модалок."""
     note_type_data = [
         (
             "Name 1",
@@ -153,7 +153,7 @@ def note_types(dbsession):
             "Name 2",
             2,
         ),
-        ("Name 3", 3, True),
+        ("Name 3", 3),
     ]
 
     note_types = [create_note_type(*note_type) for note_type in note_type_data]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+# Тут импорты
+import pytest
+from pytest import MonkeyPatch
+from pathlib import Path
+from functools import lru_cache
+from fastapi.testclient import TestClient
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from testcontainers.postgres import PostgresContainer
+from modal_backend.settings import Settings
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+class PostgresConfig:
+    """Дата-класс со значениями для контейнера с тестовой БД и для alembic-миграции."""
+    container_name: str = "modal-service-api_test"
+    username: str = "postgres"
+    host: str = "localhost"
+    external_port: int = 5432
+    image: str = "postgres:15"    
+    host_auth_method: str = "trust"
+    alembic_ini: str = Path(__file__).resolve().parent.parent / "alembic.ini"
+
+    @classmethod
+    def get_url(cls) -> str:
+        """Возвращает URI для подключения к БД."""
+        return f"postgresql://{cls.username}@{cls.host}:{cls.external_port}/postgres"
+
+@pytest.fixture(scope="session")
+def session_mp():
+    mp = MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+@pytest.fixture(scope="session")
+def get_settings_mock(session_mp):
+    """Переопределение get_settings в modal_backend/settings.py."""
+
+    @lru_cache
+    def get_test_settings():
+        test_settings = Settings()
+        test_settings.DB_DSN = PostgresConfig.get_url()
+        return test_settings
+    
+    dsn_mock = session_mp.setattr(name="modal_backend.settings.get_settings", value=get_test_settings)
+    return dsn_mock
+
+
+@pytest.fixture(scope="session")
+def get_app_with_test_settings(get_settings_mock):
+    """Загрузка app с тестовыми настройками."""
+    from modal_backend.routes import app
+    return app
+
+
+@pytest.fixture(scope="session")
+def db_container(get_settings_mock):
+    """Фикстура настройки БД для тестов в Docker-контейнере."""
+    container = (
+        PostgresContainer(
+            image=PostgresConfig.image, username=PostgresConfig.username, dbname=PostgresConfig.container_name
+        )
+        .with_bind_ports(5432, PostgresConfig.external_port)
+        .with_env("POSTGRES_HOST_AUTH_METHOD", PostgresConfig.ham)
+        .with_name(PostgresConfig.container_name)
+    )
+    container.start()
+    cfg = AlembicConfig(str(PostgresConfig.alembic_ini.resolve()))
+    cfg.set_main_option("script_location", "%(here)s/migrations")
+    command.upgrade(cfg, "head")
+    try:
+        yield PostgresConfig.get_url()
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="session")
+def engine(db_container):
+    """Фикстура настройки пула соединений к БД"""
+    engine = create_engine(str(db_container), pool_pre_ping=True)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def dbsession(engine):
+    """Фикстура настройки Session для работы с БД в тестах, реализующая паттерн 'Транзакционный откат'"""
+    #берем соединение из пула
+    connection = engine.connect()
+    #начинаем внешнюю транзакцию(на уровне соедниения)
+    transaction = connection.begin()
+    #создаём сессю на основе взятого из пула соединения
+    session = Session(bind=connection)
+    yield session
+    #закрываем сессию
+    session.close()
+    #откатываем внешнюю транзакцию, все savepoint-ы откатываются, БД чиста
+    transaction.rollback()
+    #возвращаем соединение в пул
+    connection.close()
+    
+@pytest.fixture
+def client(mocker, get_app_with_test_settings):
+    app = get_app_with_test_settings
+    client = TestClient(app)
+    return client   
+
+    
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# Тут импорты
 from functools import lru_cache
 from pathlib import Path
 
@@ -8,19 +7,20 @@ from alembic.config import Config as AlembicConfig
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
 from testcontainers.postgres import PostgresContainer
 
+from modal_backend.models.db import NoteType
 from modal_backend.settings import Settings
 
 
 class PostgresConfig:
     """Дата-класс со значениями для контейнера с тестовой БД и для alembic-миграции."""
 
-    container_name: str = "modal-service-api_test"
+    container_name: str = "modal_backend-test"
     username: str = "postgres"
     host: str = "localhost"
-    external_port: int = 5432
+    external_port: int = 5433
     image: str = "postgres:15"
     host_auth_method: str = "trust"
     alembic_ini: str = Path(__file__).resolve().parent.parent / "alembic.ini"
@@ -48,7 +48,7 @@ def get_settings_mock(session_mp):
         test_settings.DB_DSN = PostgresConfig.get_url()
         return test_settings
 
-    dsn_mock = session_mp.setattr(name="modal_backend.settings.get_settings", value=get_test_settings)
+    dsn_mock = session_mp.setattr("modal_backend.settings.get_settings", get_test_settings)
     return dsn_mock
 
 
@@ -68,11 +68,12 @@ def db_container(get_settings_mock):
             image=PostgresConfig.image, username=PostgresConfig.username, dbname=PostgresConfig.container_name
         )
         .with_bind_ports(5432, PostgresConfig.external_port)
-        .with_env("POSTGRES_HOST_AUTH_METHOD", PostgresConfig.ham)
+        .with_env("POSTGRES_HOST_AUTH_METHOD", PostgresConfig.host_auth_method)
         .with_name(PostgresConfig.container_name)
     )
     container.start()
-    cfg = AlembicConfig(str(PostgresConfig.alembic_ini.resolve()))
+    alembic_ini = PostgresConfig.alembic_ini
+    cfg = AlembicConfig(str(alembic_ini.resolve()))
     cfg.set_main_option("script_location", "%(here)s/migrations")
     command.upgrade(cfg, "head")
     try:
@@ -83,7 +84,7 @@ def db_container(get_settings_mock):
 
 @pytest.fixture(scope="session")
 def engine(db_container):
-    """Фикстура настройки пула соединений к БД"""
+    """Фикстура настройки пула соединений к БД."""
     engine = create_engine(str(db_container), pool_pre_ping=True)
     yield engine
     engine.dispose()
@@ -91,24 +92,76 @@ def engine(db_container):
 
 @pytest.fixture()
 def dbsession(engine):
-    """Фикстура настройки Session для работы с БД в тестах, реализующая паттерн 'Транзакционный откат'"""
-    # берем соединение из пула
-    connection = engine.connect()
-    # начинаем внешнюю транзакцию(на уровне соедниения)
-    transaction = connection.begin()
-    # создаём сессю на основе взятого из пула соединения
-    session = Session(bind=connection)
+    """Фикстура настройки Session для работы с БД в тестах."""
+    TestingLocalSession = sessionmaker(bind=engine)
+    session = TestingLocalSession()
     yield session
-    # закрываем сессию
     session.close()
-    # откатываем внешнюю транзакцию, все savepoint-ы откатываются, БД чиста
-    transaction.rollback()
-    # возвращаем соединение в пул
-    connection.close()
 
 
-@pytest.fixture
-def client(mocker, get_app_with_test_settings):
+@pytest.fixture()
+def authlib_user_data():
+    """
+    Данные о пользователе, возвращаемые сервисом auth.
+    """
+    return {
+        "session_scopes": [{"id": 0, "name": "string", "comment": "string"}],
+        "user_scopes": [{"id": 0, "name": "string", "comment": "string"}],
+        "indirect_groups": [{"id": 0, "name": "string", "parent_id": 0}],
+        "groups": [{"id": 0, "name": "string", "parent_id": 0}],
+        "id": 0,
+        "email": "string",
+        "userdata": [
+            {"category": "Личная информация", "param": "Полное имя", "value": "Тестовый Тест"},
+        ],
+    }
+
+
+@pytest.fixture()
+def authlib_mock(mocker):
+    auth_mock = mocker.patch("auth_lib.fastapi.UnionAuth.__call__", autospec=True)
+    return auth_mock
+
+
+@pytest.fixture()
+def user_mock(authlib_mock, authlib_user_data):
+    authlib_mock.return_value = authlib_user_data
+    return authlib_mock
+
+
+@pytest.fixture()
+def client(get_app_with_test_settings, user_mock):
     app = get_app_with_test_settings
     client = TestClient(app)
     return client
+
+
+def create_note_type(name: str, type_id: int, is_deleted: bool = False):
+    """Вспомогательная функция-мини-фабрика для создания разных типов модалок"""
+    return NoteType(name=name, type_id=type_id, is_deleted=is_deleted)
+
+
+@pytest.fixture()
+def note_types(dbsession):
+    """Создает три разных типа модалок, один тип помечен на удаление."""
+    note_type_data = [
+        (
+            "Name 1",
+            1,
+        ),
+        (
+            "Name 2",
+            2,
+        ),
+        ("Name 3", 3, True),
+    ]
+
+    note_types = [create_note_type(*note_type) for note_type in note_type_data]
+
+    for note_type in note_types:
+        dbsession.add(note_type)
+    dbsession.commit()
+    yield note_types
+    for note_type in note_types:
+        dbsession.delete(note_type)
+    dbsession.commit()

--- a/tests/test_routes/test_note_type.py
+++ b/tests/test_routes/test_note_type.py
@@ -18,7 +18,6 @@ settings = get_settings()
 def test_get_notification_type(client, note_types, status_code):
     response = client.get(url)
     assert response.status_code == status_code
-    pytest.set_trace()
     type_ids_of_note_types = [note_type.type_id for note_type in note_types]
     for note_type in response.json():
         assert note_type.get("type_id") in type_ids_of_note_types

--- a/tests/test_routes/test_note_type.py
+++ b/tests/test_routes/test_note_type.py
@@ -15,9 +15,13 @@ settings = get_settings()
         (status.HTTP_200_OK),
     ],
 )
-def test_get_notification_type(client, dbsession, note_types, status_code):
+def test_get_notification_type(client, note_types, status_code):
     response = client.get(url)
     assert response.status_code == status_code
+
+    type_ids_of_note_types = [note_type.type_id for note_type in note_types]
+    for note_type in response.json():
+        assert note_type.get("type_id") in type_ids_of_note_types
 
 
 @pytest.mark.parametrize(
@@ -40,13 +44,6 @@ def test_get_notification_type(client, dbsession, note_types, status_code):
         (
             status.HTTP_422_UNPROCESSABLE_ENTITY,
             {
-                "type_id": -100,
-                "name": "string",
-            },
-        ),
-        (
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
-            {
                 "type_id": 4,
                 "name": 123,
             },
@@ -59,10 +56,10 @@ def test_get_notification_type(client, dbsession, note_types, status_code):
             },
         ),
         (
-            status.HTTP_409_CONFLICT,
+            status.HTTP_200_OK,
             {
                 "type_id": 3,
-                "name": "NoteType with is_deleted=True",
+                "name": "Successful create NoteType with is_deleted=True",
             },
         ),
     ],

--- a/tests/test_routes/test_note_type.py
+++ b/tests/test_routes/test_note_type.py
@@ -1,0 +1,79 @@
+import pytest
+from starlette import status
+
+from modal_backend.models import NoteType
+from modal_backend.schemas.models import NoteTypeGet
+from modal_backend.settings import get_settings
+
+url: str = "/notificationtype"
+settings = get_settings()
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [
+        (status.HTTP_200_OK),
+    ],
+)
+def test_get_notification_type(client, dbsession, note_types, status_code):
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "status_code, body",
+    [
+        (
+            status.HTTP_200_OK,
+            {
+                "type_id": 4,
+                "name": "No_exist_type",
+            },
+        ),
+        (
+            status.HTTP_409_CONFLICT,
+            {
+                "type_id": 1,
+                "name": "Already_exist_type",
+            },
+        ),
+        (
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            {
+                "type_id": -100,
+                "name": "string",
+            },
+        ),
+        (
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            {
+                "type_id": 4,
+                "name": 123,
+            },
+        ),
+        (
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            {
+                "type_id": "string",
+                "name": "string",
+            },
+        ),
+        (
+            status.HTTP_409_CONFLICT,
+            {
+                "type_id": 3,
+                "name": "NoteType with is_deleted=True",
+            },
+        ),
+    ],
+)
+def test_post_create_notification_type(client, dbsession, note_types, status_code, body):
+    response = client.post(url, json=body)
+    assert response.status_code == status_code
+
+    if status_code == status.HTTP_200_OK:
+        response_model = NoteTypeGet(**response.json())
+        exist_note_type = dbsession.query(NoteType).filter(NoteType.type_id == response_model.type_id).one_or_none()
+        assert exist_note_type
+        assert exist_note_type.name == body.get("name")
+        assert exist_note_type.type_id == body.get("type_id")

--- a/tests/test_routes/test_note_type.py
+++ b/tests/test_routes/test_note_type.py
@@ -18,7 +18,7 @@ settings = get_settings()
 def test_get_notification_type(client, note_types, status_code):
     response = client.get(url)
     assert response.status_code == status_code
-
+    pytest.set_trace()
     type_ids_of_note_types = [note_type.type_id for note_type in note_types]
     for note_type in response.json():
         assert note_type.get("type_id") in type_ids_of_note_types
@@ -53,13 +53,6 @@ def test_get_notification_type(client, note_types, status_code):
             {
                 "type_id": "string",
                 "name": "string",
-            },
-        ),
-        (
-            status.HTTP_200_OK,
-            {
-                "type_id": 3,
-                "name": "Successful create NoteType with is_deleted=True",
             },
         ),
     ],


### PR DESCRIPTION
## Изменения
<!-- Опишите здесь на языке, понятном каждому, изменения, сделанные в исходном коде по пунктам. -->
- Создана базовая структура `conftest.py`(основные фикстуры для запуска и настройки контейнера, сессии и соединения).
- В `requirements.dev.txt` добавлен пакет `testcontaiters`.
- добавлены тесты и фикстуры для note_type
- Обнаружен баг, когда было возможно попытаться создать уже существующий тип модалки с флагом `is_deleted=True` - вместо `200` статус кода поднималось исключение `SQLAlchemy`. Причина в том, что `type_id`  в таблице `NoteType` имеет парметр `unitque=True`.
## Детали реализации
- После переопределения get_settings вместо перезагрузки модулей и подмены app через globals используется отдельная фикстура для получения app с тестовыми настройками.
## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
