### PR TITLE
Black fix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,7 +70,6 @@ jobs:
           requirementsFiles: "requirements.txt requirements.dev.txt"
       - uses: psf/black@stable
         with:
-          version: "~=26.0"
           options: "--check --diff"
           src: "."
       - name: Comment if linting failed

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,7 +68,11 @@ jobs:
       - uses: isort/isort-action@master
         with:
           requirementsFiles: "requirements.txt requirements.dev.txt"
-      - uses: psf/black@23.11.0
+      - uses: psf/black@stable
+        with:
+          version: "~=26.0"
+          options: "--check --diff"
+          src: "."
       - name: Comment if linting failed
         if: failure()
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,9 +69,6 @@ jobs:
         with:
           requirementsFiles: "requirements.txt requirements.dev.txt"
       - uses: psf/black@stable
-        with:
-          options: "--check --diff"
-          src: "."
       - name: Comment if linting failed
         if: failure()
         uses: thollander/actions-comment-pull-request@v2

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -6,7 +6,6 @@ from sqlalchemy import engine_from_config, pool
 from modal_backend.models.base import BaseDbModel
 from modal_backend.settings import get_settings
 
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/migrations/versions/052f7b817bbd_init.py
+++ b/migrations/versions/052f7b817bbd_init.py
@@ -1,13 +1,13 @@
 """init
 
 Revision ID: 052f7b817bbd
-Revises: 
+Revises:
 Create Date: 2026-04-17 22:21:43.978416
 
 """
+
 import sqlalchemy as sa
 from alembic import op
-
 
 # revision identifiers, used by Alembic.
 revision = '052f7b817bbd'

--- a/modal_backend/__init__.py
+++ b/modal_backend/__init__.py
@@ -1,4 +1,3 @@
 import os
 
-
 __version__ = os.getenv("APP_VERSION", "dev")

--- a/modal_backend/__main__.py
+++ b/modal_backend/__main__.py
@@ -2,6 +2,5 @@ import uvicorn
 
 from modal_backend.routes.base import app
 
-
 if __name__ == '__main__':
     uvicorn.run(app)

--- a/modal_backend/models/__init__.py
+++ b/modal_backend/models/__init__.py
@@ -1,5 +1,4 @@
 from .base import Base, BaseDbModel
 from .db import *
 
-
 __all__ = ["Base", "BaseDbModel", "NoteType", "Group", "Service", "Note", "NoteResponse"]

--- a/modal_backend/models/db.py
+++ b/modal_backend/models/db.py
@@ -22,7 +22,6 @@ from modal_backend.settings import Settings, get_settings
 
 from .base import BaseDbModel
 
-
 settings: Settings = get_settings()
 
 

--- a/modal_backend/routes/__init__.py
+++ b/modal_backend/routes/__init__.py
@@ -1,5 +1,4 @@
 from . import exc_handlers
 from .base import app
 
-
 __all__ = ["app", "exc_handlers"]

--- a/modal_backend/routes/base.py
+++ b/modal_backend/routes/base.py
@@ -9,7 +9,6 @@ from modal_backend.routes.notes import note
 from modal_backend.routes.services import service
 from modal_backend.settings import get_settings
 
-
 settings = get_settings()
 app = FastAPI(
     title='Сервис пользовательских модалок',

--- a/modal_backend/routes/groups.py
+++ b/modal_backend/routes/groups.py
@@ -8,7 +8,6 @@ from modal_backend.schemas.models import GroupGet, GroupPost
 from modal_backend.settings import Settings, get_settings
 from modal_backend.utils.services import GroupService
 
-
 settings: Settings = get_settings()
 group = APIRouter(prefix="/group", tags=["Group"])
 

--- a/modal_backend/routes/note_type.py
+++ b/modal_backend/routes/note_type.py
@@ -8,7 +8,6 @@ from modal_backend.schemas.models import NoteTypeGet, NoteTypePost
 from modal_backend.settings import Settings, get_settings
 from modal_backend.utils.services import NoteTypeService
 
-
 settings: Settings = get_settings()
 notetype = APIRouter(prefix="/notificationtype", tags=["NoteType"])
 

--- a/modal_backend/routes/notes.py
+++ b/modal_backend/routes/notes.py
@@ -23,7 +23,6 @@ from modal_backend.schemas.models import (
 from modal_backend.settings import Settings, get_settings
 from modal_backend.utils.services import NoteService
 
-
 settings: Settings = get_settings()
 note = APIRouter(prefix="/notification", tags=["Note"])
 

--- a/modal_backend/routes/services.py
+++ b/modal_backend/routes/services.py
@@ -8,7 +8,6 @@ from modal_backend.schemas.models import ServiceGet, ServicePost
 from modal_backend.settings import Settings, get_settings
 from modal_backend.utils.services import ServiceManager
 
-
 settings: Settings = get_settings()
 service = APIRouter(prefix="/service", tags=["Service"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ skip-string-normalization = true
 
 [tool.isort]
 line_length = 120
+multi_line_output = 3
 profile = "black"
+include_trailing_comma = true
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ skip-string-normalization = true
 
 [tool.isort]
 line_length = 120
-multi_line_output = 3
 profile = "black"
-lines_after_imports = 2
-include_trailing_comma = true
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 autoflake
-black==23.11.0
+black~=26.0
 httpx
 isort
 pytest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 autoflake
-black~=26.0
+black
 httpx
 isort
 pytest


### PR DESCRIPTION
## Изменения
Разобрался с новой версией форматирования black:
В начале 2026 произошел переход со стиля Black 2023 на новый стабильный стиль (26...). Создатели этого не делали три года, так что разницы в форматировании накопилось. 
Основная причина: Новый  Black не ломается, а запускается в режиме: black --check --diff и завершает работу с кодом 1, потому что часть файлов проекта была отформатирована по правилам Black 23.11.0, а Black 24–26 использует уже другой стабильный стиль. Код 1 здесь означает «файлы необходимо переформатировать», а не ошибку установки или несовместимость с Python.
В проекте есть две независимые версии:
uses: psf/black@23.11.0 (YAML) -- это версия GitHub Action.
А в requirements.dev.txt находится: black==23.11.0 - это версия самого Python-пакета Black.
При использовании: uses: psf/black@stable action по умолчанию устанавливает последнюю версию Black из PyPI. Версия action и версия установленного форматтера не обязаны совпадать.

Вообще, согласно официальному источнику:
Black гарантирует неизменность стабильного форматирования в рамках одного календарного года. В первой версии нового года разработчики могут переводить новые правила из preview-режима в stable. Поэтому большой переход с 23.11.0 на 26.x включает сразу изменения стиля 2024, 2025 и 2026 годов

То есть код всего лишь нужно один раз переформатировать новым Black и закоммитить изменения. Я собственно это и сделал.
Вот инструкция, как поступать со всеми репозиториями:
Локально развернуть проект, создать новую ветку и подключиться к ней, далее:
python -m pip install --upgrade "black~=26.0" isort
python -m isort .
python -m black --check --diff .
python -m black .
git diff
После проверки изменений:
git add .
git commit -m "Reformat code with Black 26"

Также в requirements я заменил:
black~=26.0
А в checks.yml:
- uses: psf/black@stable
      with:
        version: "~=26.0"
        options: "--check --diff"
        src: "."
Официальная документация Black рекомендует использовать psf/black@stable, а версию самого форматтера задавать отдельно через параметр version.

Также после форматирования и новой версии black возникла несогласованность правил isort и нового Black. 
Я удалил из из pyproject.toml: 
multi_line_output = 3
lines_after_imports = 2
include_trailing_comma = true
Оставив:
[tool.isort]
line_length = 120
profile = "black"
так как они уже входят в профиль profile = "black".
В новой версии Black после импортов идет 1 пустая строка.  

Теперь конфликта нет и команды:
python -m isort --check-only .
python -m black --check .
не выдают ошибок с linting.

Closes #252