### PR TITLE
Добавлена возможность зпустить тесты полностью изолированно в контейнере docker

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+ENV APP_NAME=modal_backend
+ENV APP_MODULE=${APP_NAME}.routes.base:app
+
+COPY ./requirements.txt ./requirements.dev.txt /${APP_NAME}/
+WORKDIR /${APP_NAME}/
+RUN ["/bin/sh", "-c", "pip install -U -r requirements.txt -r requirements.dev.txt"]
+CMD ["-l", "-v"]
+ENTRYPOINT ["pytest"]
+
+COPY ./pyproject.toml /${APP_NAME}/
+COPY ./alembic.ini /${APP_NAME}/
+COPY ./migrations /${APP_NAME}/migrations
+COPY ./${APP_NAME} /${APP_NAME}/${APP_NAME}
+COPY ./tests /${APP_NAME}/tests/

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ pytest-container-run:
 	 --add-host host.docker.internal:host-gateway \
 	 -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
 	 --network host \
-	 pytest-container
+	 pytest-container \
+	 $(ARGS)
 
 pytest-rerun:
 	docker build -f Dockerfile.test -t pytest-container . \
@@ -45,7 +46,9 @@ pytest-rerun:
 	--add-host host.docker.internal:host-gateway \
 	-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
 	--network host \
-	pytest-container
+	pytest-container \
+	$(ARGS)
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,16 @@ pytest-container-run:
 	 --network host \
 	 pytest-container
 
+pytest-rerun:
+	docker build -f Dockerfile.test -t pytest-container . \
+	&& \
+	docker run -it \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	--rm \
+	--add-host host.docker.internal:host-gateway \
+	-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+	--network host \
+	pytest-container
+
+
 

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,17 @@ db:
 
 migrate:
 	source ./venv/bin/activate && alembic upgrade head
+
+pytest-container-build:
+	 docker build -f Dockerfile.test -t pytest-container .
+
+pytest-container-run:
+	 docker run -it \
+	 -v /var/run/docker.sock:/var/run/docker.sock \
+	 --rm \
+	 --add-host host.docker.internal:host-gateway \
+	 -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
+	 --network host \
+	 pytest-container
+
+


### PR DESCRIPTION
## Изменения
<!-- Опишите здесь на языке, понятном каждому, изменения, сделанные в ис- ходном коде по пунктам. -->
- Добавлен файл образа для тестов `Dockerfile.test` для билда контейнера с тестами
- Добавлены make-команды `pytest-container-build`, `pytest-container-run` и `pytest-rerun` для сборки и запуска контейнера с тестами.
## Детали реализации
<!-- Здесь можно описать технические детали по пунктам. -->
- Так как в тестах происходит запуск контейнера внутри контейнера(docker-in-docker) используется проброс сокета `docker.sock` и подмены записи в `etc/hosts` на специальное DNS-имя `host.docker.internal` для организации связи с хостом.
## Проблемы, которые решает
- Полная изоляция системного окружения при запуске тестов
- Гарантия запуска тестов с обновленными зависимостями проекта
## Вопросики
- Возможно изоляция от системы не имеет смысла. Проблему, котрую я хотел решить заключалась в ситуации, когда мы запускали тесты и у каждого были свои зависимости проекта, что привело к разным результам прогона. Для этого, можно было бы использовать sh-скрипт или git-хуки, возможно контейнер избыточен, хотя как будто более универсален.
## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
